### PR TITLE
Remove name column that prevents heroku migration

### DIFF
--- a/lib/plant_coach_guides.csv
+++ b/lib/plant_coach_guides.csv
@@ -1,4 +1,4 @@
-plant_type,name
+plant_type
 Tomato,
 Pepper,
 Eggplant,


### PR DESCRIPTION
## What was the change?
- Quick fix to resolve an issue with running the rake tasks in Heroku.
- Erroneous `name` column was removed.


## Fix Categories
- [x] Bug fix
- [ ] New Feature (non-breaking change that adds functionality)
- [ ] This change requires an update to documentation
- [ ] Refactor
- [ ] Database structure changes
- [ ] Resiliency Enhancement


## Developer Standards
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have verified this change doesn't adversely affect another microservice, and if it does, I have opened an issue.
- [ ] Overall, I have left the codebase better than I found it.

### SimpleCov test coverage:
- 100%
