### PR TITLE
Feature/issue 165

### DIFF
--- a/app/models/garden_plant.rb
+++ b/app/models/garden_plant.rb
@@ -34,6 +34,8 @@ class GardenPlant < ApplicationRecord
   enum seed_sew_type: [:not_specified, :not_applicable, :direct, :indirect]
 
   before_save :update_planting_dates, if: :actual_seed_sewing_date_changed?
+  before_save :update_direct_seed_dates, if: :status_changed_from_not_started_to_direct_sewn
+
   # A GardenPlant requires fields that must be filled in and calculated by
   # SeedDefaultData.  This triggers the process after #create is called.
   after_initialize :seed_sew_type_not_applicable, if: :start_from_seed_false
@@ -88,7 +90,9 @@ class GardenPlant < ApplicationRecord
     self.recommended_seed_sewing_date = self.recommended_transplant_date
   end
 
-
+  def update_direct_seed_dates
+    self.actual_seed_sewing_date = self.actual_transplant_date
+  end
   
 private
   def immediate_transplant
@@ -113,5 +117,9 @@ private
 
   def direct_future_sew
     self.seed_sew_type == "direct" && actual_seed_sewing_date.nil?
+  end
+
+  def status_changed_from_not_started_to_direct_sewn
+    planting_status_changed?(from: "not_started", to: "direct_sewn_outside")
   end
 end

--- a/app/models/garden_plant.rb
+++ b/app/models/garden_plant.rb
@@ -17,7 +17,7 @@ class GardenPlant < ApplicationRecord
   validates :start_from_seed, inclusion: [true, false]
   validates :actual_transplant_date, presence: {
     message: "You must specify a transplant date!" }, unless: -> { 
-      planting_status != "transplanted_outside" 
+      ["transplanted_outside", "direct_sewn_outside"].exclude?(planting_status)
     }
 
   belongs_to :user
@@ -51,8 +51,8 @@ class GardenPlant < ApplicationRecord
 
   def generate_key_plant_dates
     user = User.find_by(id: self.user_id)
-    default_seed_data = SeedDefaultData.find_by(plant_type: self.plant_type).seedling_days_to_transplant
 
+    default_seed_data = SeedDefaultData.find_by(plant_type: self.plant_type).seedling_days_to_transplant
     self.recommended_transplant_date = user.spring_frost_dates.to_date + self.days_relative_to_frost_date
     self.recommended_seed_sewing_date = user.spring_frost_dates.to_date + self.days_relative_to_frost_date - default_seed_data
     self.seedling_days_to_transplant = default_seed_data

--- a/spec/fixtures/vcr_cassettes/Garden_Plants_API_Endpoint/PATCH_/garden_plants/when_updating_a_GardenPlants_planting_status/from_Not_Started_to_Direct_Seeded_Outside/will_return_an_error_if_the_necessary_information_was_not_provided.yml
+++ b/spec/fixtures/vcr_cassettes/Garden_Plants_API_Endpoint/PATCH_/garden_plants/when_updating_a_GardenPlants_planting_status/from_Not_Started_to_Direct_Seeded_Outside/will_return_an_error_if_the_necessary_information_was_not_provided.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://glacial-fjord-58347.herokuapp.com/api/v1/frost?zip_code=80121
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.5.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Wed, 08 Mar 2023 05:21:03 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"43098a6258e79296c49fb455c2cd482f"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - b1ecd09b-b504-4aba-a9d9-6b8e37c09f5a
+      X-Runtime:
+      - '0.683199'
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"data":{"id":null,"type":"frost_date","attributes":{"id":null,"zip_code":"80121","location_name":"Greenwood
+        Village","lat":39.6111,"lon":-104.9532,"spring_frost":"0520","fall_frost":"0924"}}}'
+  recorded_at: Wed, 08 Mar 2023 05:21:04 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/Garden_Plants_API_Endpoint/PATCH_/garden_plants/when_updating_a_GardenPlants_planting_status/from_Not_Started_to_Direct_Seeded_Outside/will_update_the_appropriate_attributes.yml
+++ b/spec/fixtures/vcr_cassettes/Garden_Plants_API_Endpoint/PATCH_/garden_plants/when_updating_a_GardenPlants_planting_status/from_Not_Started_to_Direct_Seeded_Outside/will_update_the_appropriate_attributes.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://glacial-fjord-58347.herokuapp.com/api/v1/frost?zip_code=80121
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.5.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Wed, 08 Mar 2023 05:06:08 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"43098a6258e79296c49fb455c2cd482f"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 80b72cf3-8001-4681-a798-f5c56beb78ea
+      X-Runtime:
+      - '0.370735'
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"data":{"id":null,"type":"frost_date","attributes":{"id":null,"zip_code":"80121","location_name":"Greenwood
+        Village","lat":39.6111,"lon":-104.9532,"spring_frost":"0520","fall_frost":"0924"}}}'
+  recorded_at: Wed, 08 Mar 2023 05:06:07 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/Garden_Plants_API_Endpoint/PATCH_/garden_plants/when_updating_a_GardenPlants_planting_status/from_Not_Started_to_Direct_Seeded_Outside/will_update_the_status_and_transplant_date.yml
+++ b/spec/fixtures/vcr_cassettes/Garden_Plants_API_Endpoint/PATCH_/garden_plants/when_updating_a_GardenPlants_planting_status/from_Not_Started_to_Direct_Seeded_Outside/will_update_the_status_and_transplant_date.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://glacial-fjord-58347.herokuapp.com/api/v1/frost?zip_code=80121
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.5.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Wed, 08 Mar 2023 05:36:53 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"43098a6258e79296c49fb455c2cd482f"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - bbd6928a-346b-4210-ad35-36e6f7e9f816
+      X-Runtime:
+      - '0.524814'
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"data":{"id":null,"type":"frost_date","attributes":{"id":null,"zip_code":"80121","location_name":"Greenwood
+        Village","lat":39.6111,"lon":-104.9532,"spring_frost":"0520","fall_frost":"0924"}}}'
+  recorded_at: Wed, 08 Mar 2023 05:36:54 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/Garden_Plants_API_Endpoint/PATCH_/garden_plants/when_updating_a_GardenPlants_planting_status/from_not_started_inside_to_transplanted_outside/will_only_update_the_object_when_an_actual_transplant_date_is_passed.yml
+++ b/spec/fixtures/vcr_cassettes/Garden_Plants_API_Endpoint/PATCH_/garden_plants/when_updating_a_GardenPlants_planting_status/from_not_started_inside_to_transplanted_outside/will_only_update_the_object_when_an_actual_transplant_date_is_passed.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://glacial-fjord-58347.herokuapp.com/api/v1/frost?zip_code=80121
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.5.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Wed, 08 Mar 2023 05:06:07 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"43098a6258e79296c49fb455c2cd482f"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - b602b3b4-5e3e-4146-a99f-d820c6d21df4
+      X-Runtime:
+      - '0.502959'
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"data":{"id":null,"type":"frost_date","attributes":{"id":null,"zip_code":"80121","location_name":"Greenwood
+        Village","lat":39.6111,"lon":-104.9532,"spring_frost":"0520","fall_frost":"0924"}}}'
+  recorded_at: Wed, 08 Mar 2023 05:06:06 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/Garden_Plants_API_Endpoint/PATCH_/garden_plants/when_updating_a_GardenPlants_planting_status/from_not_started_inside_to_transplanted_outside/will_return_a_meaningful_error_response_if_the_frontend_doesnt_provide_an_actual_transplant_date.yml
+++ b/spec/fixtures/vcr_cassettes/Garden_Plants_API_Endpoint/PATCH_/garden_plants/when_updating_a_GardenPlants_planting_status/from_not_started_inside_to_transplanted_outside/will_return_a_meaningful_error_response_if_the_frontend_doesnt_provide_an_actual_transplant_date.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://glacial-fjord-58347.herokuapp.com/api/v1/frost?zip_code=80121
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.5.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Wed, 08 Mar 2023 05:06:06 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"43098a6258e79296c49fb455c2cd482f"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 968e1dfb-b6ea-4aa3-90f0-9fa35ae3d2bb
+      X-Runtime:
+      - '0.547653'
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"data":{"id":null,"type":"frost_date","attributes":{"id":null,"zip_code":"80121","location_name":"Greenwood
+        Village","lat":39.6111,"lon":-104.9532,"spring_frost":"0520","fall_frost":"0924"}}}'
+  recorded_at: Wed, 08 Mar 2023 05:06:06 GMT
+recorded_with: VCR 6.1.0

--- a/spec/requests/api/v1/garden_plants_request_spec.rb
+++ b/spec/requests/api/v1/garden_plants_request_spec.rb
@@ -24,6 +24,13 @@ RSpec.describe 'Garden Plants API Endpoint', :vcr do
       days_relative_to_frost_date: 14,
       direct_seed_recommended: false
     )
+    radish_seed = SeedDefaultData.create(
+      plant_type: "Radish",
+      days_to_maturity: 30,
+      seedling_days_to_transplant: 0,
+      days_relative_to_frost_date: -60,
+      direct_seed_recommended: true
+    )
 
     post '/api/v1/users', params: body
   end
@@ -294,8 +301,8 @@ RSpec.describe 'Garden Plants API Endpoint', :vcr do
 
   describe 'PATCH /garden_plants' do
     context 'when updating a GardenPlants planting status' do
-      describe 'from not started to transplanted outside' do
-        it 'will require the user to provide an actual transplant date' do
+      describe 'from not started inside to transplanted outside' do
+        it 'will return a meaningful error response if the frontend doesnt provide an actual transplant date' do
           post '/api/v1/garden_plants', params: {
             plant_id: plant1_object.id,
             plant_type: "Tomato",
@@ -347,7 +354,60 @@ RSpec.describe 'Garden Plants API Endpoint', :vcr do
           expect(result[:data][:attributes][:actual_transplant_date].to_date).to eq(Date.today)
         end
       end
+
+      describe 'from Not Started to Direct Seeded Outside' do
+        it 'will update the appropriate attributes' do
+          post '/api/v1/garden_plants', params: {
+            plant_id: plant1_object.id,
+            plant_type: "Radish",
+            name: "French Breakfast",
+            days_relative_to_frost_date: -45,
+            days_to_maturity: 30,
+            hybrid_status: :unknown,
+            start_from_seed: true,
+            actual_seed_sewing_date: nil,
+            seed_sew_type: :direct,
+            planting_status: "not_started"
+          }
+
+          new_garden_plant = GardenPlant.last
+
+          patch "/api/v1/garden_plants/#{new_garden_plant.id}", params: {
+            planting_status: "direct_sewn_outside", 
+            actual_transplant_date: Date.today
+          }
+          result = JSON.parse(response.body, symbolize_names: true)
+
+          expect(result[:data][:attributes][:planting_status]).to eq("direct_sewn_outside")
+          expect(result[:data][:attributes][:actual_transplant_date].to_date).to eq(Date.today)
+        end
+
+        it 'will return an error if the necessary information was not provided' do
+          post '/api/v1/garden_plants', params: {
+            plant_id: plant1_object.id,
+            plant_type: "Radish",
+            name: "French Breakfast",
+            days_relative_to_frost_date: -45,
+            days_to_maturity: 30,
+            hybrid_status: :unknown,
+            start_from_seed: true,
+            actual_seed_sewing_date: nil,
+            seed_sew_type: :direct,
+            planting_status: "not_started"
+          }
+
+          new_garden_plant = GardenPlant.last
+
+          patch "/api/v1/garden_plants/#{new_garden_plant.id}", params: {
+            planting_status: "direct_sewn_outside"
+          }
+          result = JSON.parse(response.body, symbolize_names: true)
+          
+          expect(result[:error]).to eq("You must specify a transplant date!")
+        end
+      end
     end
+
     it 'allows the user to add an actual planting date to an existing garden_plant' do
       post '/api/v1/garden_plants', params: {
         plant_id: plant1_object.id,

--- a/spec/requests/api/v1/garden_plants_request_spec.rb
+++ b/spec/requests/api/v1/garden_plants_request_spec.rb
@@ -356,7 +356,7 @@ RSpec.describe 'Garden Plants API Endpoint', :vcr do
       end
 
       describe 'from Not Started to Direct Seeded Outside' do
-        it 'will update the appropriate attributes' do
+        it 'will update the status and transplant date' do
           post '/api/v1/garden_plants', params: {
             plant_id: plant1_object.id,
             plant_type: "Radish",
@@ -380,6 +380,8 @@ RSpec.describe 'Garden Plants API Endpoint', :vcr do
 
           expect(result[:data][:attributes][:planting_status]).to eq("direct_sewn_outside")
           expect(result[:data][:attributes][:actual_transplant_date].to_date).to eq(Date.today)
+          expect(result[:data][:attributes][:actual_seed_sewing_date]).to_not be nil
+          expect(result[:data][:attributes][:actual_seed_sewing_date].to_date).to eq(Date.today)
         end
 
         it 'will return an error if the necessary information was not provided' do


### PR DESCRIPTION
## What was the change?
- A scenario/user story was implemented in which a user changes the status of a plant from `not started` to `direct sewn outside`.  
- Test coverage was added for happy and sad paths.
- Business logic was added to ensure that when this exact status change is made that the `actual_transplant_date` and `actual_seed_sewing_date` match to demonstrate that something was direct-seeded.


## Fix Categories
- [ ] Bug fix
- [x] New Feature (non-breaking change that adds functionality)
- [ ] This change requires an update to documentation
- [ ] Refactor
- [ ] Database structure changes
- [ ] Resiliency Enhancement
- [ ] Documemtation update


## Developer Standards
**I agree to the following as part of this Pull Request:**

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
- I have verified this change doesn't adversely affect another microservice, and if it does, I have opened an issue.
- Overall, I have left the codebase better than I found it.

### SimpleCov test coverage:
- 99.85%
