### PR TITLE
Feature/issue 164

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@
 
 # Ignore application configuration
 /config/application.yml
+
+# Ignore the .VSCodeCounter extension files added from VSCode
+/.VSCodeCounter

--- a/app/controllers/api/v1/garden_plants_controller.rb
+++ b/app/controllers/api/v1/garden_plants_controller.rb
@@ -19,10 +19,13 @@ class Api::V1::GardenPlantsController < ApplicationController
   def update
     garden_plant = @user.garden_plants.find_by(id: params[:id])
     result = garden_plant.update(garden_plant_params)
+
     if garden_plant.valid?
       render json: GardenPlantSerializer.new(garden_plant)
     elsif !garden_plant.errors[:actual_transplant_date].empty?
       render json: GardenPlantSerializer.error(garden_plant.errors[:actual_transplant_date].first)
+    elsif !garden_plant.errors[:actual_seed_sewing_date].empty?
+      render json: GardenPlantSerializer.error(garden_plant.errors[:actual_seed_sewing_date].first)
     end
   end
 

--- a/app/models/garden_plant.rb
+++ b/app/models/garden_plant.rb
@@ -19,6 +19,11 @@ class GardenPlant < ApplicationRecord
     message: "You must specify a transplant date!" }, unless: -> { 
       ["transplanted_outside", "direct_sewn_outside"].exclude?(planting_status)
     }
+  validates :actual_seed_sewing_date, presence: {
+    message: "You must specify a seed-sewing date!" }, unless: -> {
+      ["started_indoors"].exclude?(planting_status)
+    }
+  
 
   belongs_to :user
   has_many :transplant_coachings

--- a/spec/fixtures/vcr_cassettes/Garden_Plants_API_Endpoint/PATCH_/garden_plants/when_updating_a_GardenPlants_planting_status/from_not_started_to_started_indoors/returns_a_meaningful_error_response_if_the_frontend_doesnt_provide_.yml
+++ b/spec/fixtures/vcr_cassettes/Garden_Plants_API_Endpoint/PATCH_/garden_plants/when_updating_a_GardenPlants_planting_status/from_not_started_to_started_indoors/returns_a_meaningful_error_response_if_the_frontend_doesnt_provide_.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://glacial-fjord-58347.herokuapp.com/api/v1/frost?zip_code=80121
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.5.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Thu, 09 Mar 2023 02:40:59 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"43098a6258e79296c49fb455c2cd482f"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 133a07ea-eaa1-4f10-9ffe-88932bf18e00
+      X-Runtime:
+      - '0.524452'
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"data":{"id":null,"type":"frost_date","attributes":{"id":null,"zip_code":"80121","location_name":"Greenwood
+        Village","lat":39.6111,"lon":-104.9532,"spring_frost":"0520","fall_frost":"0924"}}}'
+  recorded_at: Thu, 09 Mar 2023 02:40:59 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/Garden_Plants_API_Endpoint/PATCH_/garden_plants/when_updating_a_GardenPlants_planting_status/from_not_started_to_started_indoors/returns_will_update_the_planting_status_and_the_seed-sewing_date.yml
+++ b/spec/fixtures/vcr_cassettes/Garden_Plants_API_Endpoint/PATCH_/garden_plants/when_updating_a_GardenPlants_planting_status/from_not_started_to_started_indoors/returns_will_update_the_planting_status_and_the_seed-sewing_date.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://glacial-fjord-58347.herokuapp.com/api/v1/frost?zip_code=80121
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.5.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Thu, 09 Mar 2023 02:56:01 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"43098a6258e79296c49fb455c2cd482f"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 819001dc-8a3d-4ed5-adbd-a99c2a1b8cba
+      X-Runtime:
+      - '0.456115'
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"data":{"id":null,"type":"frost_date","attributes":{"id":null,"zip_code":"80121","location_name":"Greenwood
+        Village","lat":39.6111,"lon":-104.9532,"spring_frost":"0520","fall_frost":"0924"}}}'
+  recorded_at: Thu, 09 Mar 2023 02:56:02 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/Garden_Plants_API_Endpoint/PATCH_/garden_plants/when_updating_a_GardenPlants_planting_status/from_not_started_to_transplanted_outside/will_return_a_meaningful_error_response_if_the_frontend_doesnt_provide_an_actual_transplant_date.yml
+++ b/spec/fixtures/vcr_cassettes/Garden_Plants_API_Endpoint/PATCH_/garden_plants/when_updating_a_GardenPlants_planting_status/from_not_started_to_transplanted_outside/will_return_a_meaningful_error_response_if_the_frontend_doesnt_provide_an_actual_transplant_date.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://glacial-fjord-58347.herokuapp.com/api/v1/frost?zip_code=80121
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.5.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Thu, 09 Mar 2023 02:52:24 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"43098a6258e79296c49fb455c2cd482f"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 7dfb313d-616a-4aa6-9166-d1d7ab51ddb8
+      X-Runtime:
+      - '0.623771'
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"data":{"id":null,"type":"frost_date","attributes":{"id":null,"zip_code":"80121","location_name":"Greenwood
+        Village","lat":39.6111,"lon":-104.9532,"spring_frost":"0520","fall_frost":"0924"}}}'
+  recorded_at: Thu, 09 Mar 2023 02:52:24 GMT
+recorded_with: VCR 6.1.0

--- a/spec/requests/api/v1/garden_plants_request_spec.rb
+++ b/spec/requests/api/v1/garden_plants_request_spec.rb
@@ -301,7 +301,62 @@ RSpec.describe 'Garden Plants API Endpoint', :vcr do
 
   describe 'PATCH /garden_plants' do
     context 'when updating a GardenPlants planting status' do
-      describe 'from not started inside to transplanted outside' do
+      describe 'from not started to started indoors' do
+        it 'returns will update the planting status and the seed-sewing date' do
+          post '/api/v1/garden_plants', params: {
+            plant_id: plant1_object.id,
+            plant_type: "Tomato",
+            name: "Sungold",
+            days_relative_to_frost_date: 14,
+            days_to_maturity: 54,
+            hybrid_status: :open_pollinated,
+            organic: false,
+            start_from_seed: true,
+            actual_seed_sewing_date: nil,
+            seed_sew_type: :not_applicable,
+            planting_status: "not_started"
+          }
+
+          new_garden_plant = GardenPlant.last
+
+          patch "/api/v1/garden_plants/#{new_garden_plant.id}", params: {
+            planting_status: "started_indoors",
+            actual_seed_sewing_date: Date.today
+          }
+          result = JSON.parse(response.body, symbolize_names: true)
+
+          expect(result[:data][:attributes][:planting_status]).to eq("started_indoors")
+          expect(result[:data][:attributes][:actual_seed_sewing_date]).to_not be nil
+          expect(result[:data][:attributes][:actual_seed_sewing_date].to_date).to eq(Date.today)
+        end
+
+        it 'returns a meaningful error response if the frontend doesnt provide...' do
+          post '/api/v1/garden_plants', params: {
+            plant_id: plant1_object.id,
+            plant_type: "Tomato",
+            name: "Sungold",
+            days_relative_to_frost_date: 14,
+            days_to_maturity: 54,
+            hybrid_status: :open_pollinated,
+            organic: false,
+            start_from_seed: true,
+            actual_seed_sewing_date: nil,
+            seed_sew_type: :not_applicable,
+            planting_status: "not_started"
+          }
+
+          new_garden_plant = GardenPlant.last
+
+          patch "/api/v1/garden_plants/#{new_garden_plant.id}", params: {
+            planting_status: "started_indoors"
+          }
+          result = JSON.parse(response.body, symbolize_names: true)
+
+          expect(result[:error]).to eq("You must specify a seed-sewing date!")
+        end
+      end
+      
+      describe 'from not started to transplanted outside' do
         it 'will return a meaningful error response if the frontend doesnt provide an actual transplant date' do
           post '/api/v1/garden_plants', params: {
             plant_id: plant1_object.id,


### PR DESCRIPTION
## What was the change?
- User store implemented in which a user moves the status of a plant from `not started` to `started indoors`.
- This requires that logic be implemented to also require that a date be provided for the record to be updated.
- This is a bonus for FE development as the error is meant to be feedback for the FE service instead of intended for the user as FE logic should prevent this from happening.
- Tests!


## Fix Categories
- [ ] Bug fix
- [x] New Feature (non-breaking change that adds functionality)
- [ ] This change requires an update to documentation
- [ ] Refactor
- [ ] Database structure changes
- [ ] Resiliency Enhancement
- [ ] Documemtation update


## Developer Standards
**I agree to the following as part of this Pull Request:**

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
- I have verified this change doesn't adversely affect another microservice, and if it does, I have opened an issue.
- Overall, I have left the codebase better than I found it.

### SimpleCov test coverage:
- 99.85%
