### PR TITLE
DELETE `/plants/:plants_id` should be done based on `User`

### DIFF
--- a/app/controllers/api/v1/plants_controller.rb
+++ b/app/controllers/api/v1/plants_controller.rb
@@ -30,7 +30,7 @@ class Api::V1::PlantsController < ApplicationController
   end
 
   def destroy
-    plant = Plant.find_by(id: params[:id])
+    plant = @user.plants.find_by(id: params[:id])
     if !plant.nil?
       deleted_plant = plant.destroy
       render json: PlantSerializer.new(deleted_plant), status: :ok


### PR DESCRIPTION
## What was the change?
- Deleting a plant is now done referenced from the @user in the controller rather than having free reign to search the entire database with no mention of the correct user.  This was a necessary change to reflect the true behavior and relationships of the database and application.
- This resolved: #253 


## Fix Categories
- [x] Bug fix
- [ ] New Feature (non-breaking change that adds functionality)
- [ ] This change requires an update to documentation
- [ ] Refactor
- [ ] Database structure changes
- [ ] Resiliency Enhancement
- [ ] Documemtation update


## Developer Standards
**I agree to the following as part of this Pull Request:**

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
- I have verified this change doesn't adversely affect another microservice, and if it does, I have opened an issue.
- Overall, I have left the codebase better than I found it.

### Application Testing
Overall Test Coverage: **98.28%**
New Tests Added: **0**
Skipped Tests: **<#>**


<img src="https://media1.giphy.com/media/Rl9Yqavfj2Ula/giphy.gif"/>